### PR TITLE
Fix handling null result

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -160,7 +160,7 @@ var shopifyXML = function(url, callback) {
                 productDetails: []
             }
 
-            if (typeof result === null) {
+            if (result === null) {
                 console.log(`${url} crashed.`)
                 process.exit()
             }


### PR DESCRIPTION
[typeof](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof#null) returns a string and will return 'object' if used on a value that is null